### PR TITLE
add github to known host

### DIFF
--- a/ansible/roles/clone-repo/tasks/main.yml
+++ b/ansible/roles/clone-repo/tasks/main.yml
@@ -21,6 +21,11 @@
     state: directory
   when: not workspace.stat.exists
 
+- name: add github in known hosts
+  ansible.builtin.shell: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+  args:
+    executable: /bin/bash
+
 - name: Clone the db repository
   ansible.builtin.git:
     repo: "{{ git_base_url }}db.git"


### PR DESCRIPTION
fix git clone not working if github was not in known_hosts

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/af04edeb-4c4e-46e8-80ec-a86aa4eddd7a" />
